### PR TITLE
A workaround added for ChromeOptions.merge() arguments issue

### DIFF
--- a/src/main/java/com/wiley/driver/factory/capabilities/ChromeCaps.java
+++ b/src/main/java/com/wiley/driver/factory/capabilities/ChromeCaps.java
@@ -7,6 +7,8 @@ import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Caps for Chrome browser on any platform (Windows, Linux, Mac)
@@ -28,6 +30,11 @@ public class ChromeCaps extends TeasyCaps {
         ChromeOptions caps = getChromeOptions();
         if (!this.customCaps.asMap().isEmpty()) {
             caps.merge(this.customCaps);
+
+            // This is a workaround for ChromeOptions.merge() issue when passed arguments are not being assigned properly
+            Map chromeCapability = (Map) caps.getCapability(ChromeOptions.CAPABILITY);
+            List argumentsList = (List) chromeCapability.get("args");
+            argumentsList.forEach(o -> caps.addArguments(o.toString()));
         }
         return caps;
     }

--- a/src/main/java/com/wiley/driver/factory/capabilities/ChromeCaps.java
+++ b/src/main/java/com/wiley/driver/factory/capabilities/ChromeCaps.java
@@ -33,8 +33,8 @@ public class ChromeCaps extends TeasyCaps {
 
             // This is a workaround for ChromeOptions.merge() issue when passed arguments are not being assigned properly
             Map chromeCapability = (Map) caps.getCapability(ChromeOptions.CAPABILITY);
-            List argumentsList = (List) chromeCapability.get("args");
-            argumentsList.forEach(o -> caps.addArguments(o.toString()));
+            List arguments = (List) chromeCapability.get("args");
+            arguments.forEach(o -> caps.addArguments(o.toString()));
         }
         return caps;
     }

--- a/src/main/java/com/wiley/driver/factory/capabilities/ChromeCaps.java
+++ b/src/main/java/com/wiley/driver/factory/capabilities/ChromeCaps.java
@@ -26,17 +26,18 @@ public class ChromeCaps extends TeasyCaps {
         this.platform = platform;
     }
 
+    @SuppressWarnings("unchecked") // Just in case getCapability return value type changes in future versions
     public ChromeOptions get() {
-        ChromeOptions caps = getChromeOptions();
+        ChromeOptions chromeOptions = getChromeOptions();
         if (!this.customCaps.asMap().isEmpty()) {
-            caps.merge(this.customCaps);
+            chromeOptions.merge(this.customCaps);
 
             // This is a workaround for ChromeOptions.merge() issue when passed arguments are not being assigned properly
-            Map chromeCapability = (Map) caps.getCapability(ChromeOptions.CAPABILITY);
-            List arguments = (List) chromeCapability.get("args");
-            arguments.forEach(o -> caps.addArguments(o.toString()));
+            Map<String, Object> chromeCapability = (Map<String, Object>) chromeOptions.getCapability(ChromeOptions.CAPABILITY);
+            List<String> arguments = (List<String>) chromeCapability.get("args");
+            arguments.forEach(chromeOptions::addArguments);
         }
-        return caps;
+        return chromeOptions;
     }
 
     private ChromeOptions getChromeOptions() {


### PR DESCRIPTION
@vefimofff please review solution for arguments merge issue. If no changes required, it would be nice to have this change in next teasy release.