### PR TITLE
Deprecated Locatable imports fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.wiley</groupId>
     <artifactId>teasy</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.9</version>
+    <version>2.0.10</version>
 
     <name>Teasy</name>
     <description>Automation framework to make testing easy</description>

--- a/src/main/java/com/wiley/elements/types/BaseTeasyElement.java
+++ b/src/main/java/com/wiley/elements/types/BaseTeasyElement.java
@@ -361,7 +361,7 @@ public abstract class BaseTeasyElement implements TeasyElement, org.openqa.selen
 
     @Override
     public Coordinates getCoordinates() {
-        return ((org.openqa.selenium.interactions.internal.Locatable) getWrappedWebElement()).getCoordinates();
+        return ((org.openqa.selenium.interactions.Locatable) getWrappedWebElement()).getCoordinates();
     }
 
     @Override

--- a/src/main/java/com/wiley/elements/types/BaseTeasyElement.java
+++ b/src/main/java/com/wiley/elements/types/BaseTeasyElement.java
@@ -30,7 +30,7 @@ import static com.wiley.utils.JsActions.executeScript;
 /**
  * General implementation with all basic logic of an element
  */
-public abstract class BaseTeasyElement implements TeasyElement, org.openqa.selenium.interactions.internal.Locatable {
+public abstract class BaseTeasyElement implements TeasyElement, org.openqa.selenium.interactions.Locatable {
 
     private WebElement wrappedElement;
     private Locatable locatable;

--- a/src/main/java/com/wiley/elements/types/NullTeasyElement.java
+++ b/src/main/java/com/wiley/elements/types/NullTeasyElement.java
@@ -18,7 +18,7 @@ import static com.wiley.holders.DriverHolder.getDriver;
 /**
  * Represents element that is absent (not found)
  */
-public class NullTeasyElement implements TeasyElement, org.openqa.selenium.interactions.internal.Locatable {
+public class NullTeasyElement implements TeasyElement, org.openqa.selenium.interactions.Locatable {
 
     private TeasyElementData elementData;
     private Locatable locatable;


### PR DESCRIPTION
Using deprecated Locatable led to type cast error in Actions methods, fixed now (bundled tests are also passed)