### PR TITLE
[NullTeasyElement] added public getter of elementData

### DIFF
--- a/src/main/java/com/wiley/elements/TeasyElement.java
+++ b/src/main/java/com/wiley/elements/TeasyElement.java
@@ -55,6 +55,13 @@ public interface TeasyElement extends WebElement {
     Locatable getLocatable();
 
     /**
+     * Gets data used for element creation (e.g. search context, locator)
+     *
+     * @return - {@link TeasyElementData}
+     */
+    TeasyElementData getElementData();
+
+    /**
      * {@link #should(SearchStrategy)} with default {@link SearchStrategy}
      */
     Should should();

--- a/src/main/java/com/wiley/elements/types/BaseTeasyElement.java
+++ b/src/main/java/com/wiley/elements/types/BaseTeasyElement.java
@@ -32,6 +32,7 @@ import static com.wiley.utils.JsActions.executeScript;
  */
 public abstract class BaseTeasyElement implements TeasyElement, org.openqa.selenium.interactions.Locatable {
 
+    private TeasyElementData elementData;
     private WebElement wrappedElement;
     private Locatable locatable;
     private int repeatLocateElementCounter;
@@ -41,6 +42,7 @@ public abstract class BaseTeasyElement implements TeasyElement, org.openqa.selen
     private static final int MAX_NUMBER_OF_REPEAT_LOCATE_ELEMENT = 20;
 
     BaseTeasyElement(TeasyElementData elementData) {
+        this.elementData = elementData;
         this.locatable = new LocatableFactory(elementData, getDriver()).get();
         this.repeatLocateElementCounter = 0;
         this.wrappedElement = getWrappedElement(elementData);
@@ -367,6 +369,11 @@ public abstract class BaseTeasyElement implements TeasyElement, org.openqa.selen
     @Override
     public Locatable getLocatable() {
         return locatable;
+    }
+
+    @Override
+    public TeasyElementData getElementData() {
+        return elementData;
     }
 
     @Override

--- a/src/main/java/com/wiley/elements/types/NullTeasyElement.java
+++ b/src/main/java/com/wiley/elements/types/NullTeasyElement.java
@@ -48,11 +48,6 @@ public class NullTeasyElement implements TeasyElement, org.openqa.selenium.inter
         return new NullElementWaitFor(elementData, new TeasyFluentWait<>(getDriver(), strategy), strategy);
     }
 
-    // this will allow to get search context and to perform a lookup of the same element if needed
-    public TeasyElementData getElementData() {
-        return elementData;
-    }
-
     /*
       All other methods of TeasyElement should throw an exception because it's not possible to
       interact with element that does not exist
@@ -151,6 +146,11 @@ public class NullTeasyElement implements TeasyElement, org.openqa.selenium.inter
     @Override
     public Locatable getLocatable() {
         return locatable;
+    }
+
+    @Override
+    public TeasyElementData getElementData() {
+        return elementData;
     }
 
     @Override

--- a/src/main/java/com/wiley/elements/types/NullTeasyElement.java
+++ b/src/main/java/com/wiley/elements/types/NullTeasyElement.java
@@ -48,6 +48,11 @@ public class NullTeasyElement implements TeasyElement, org.openqa.selenium.inter
         return new NullElementWaitFor(elementData, new TeasyFluentWait<>(getDriver(), strategy), strategy);
     }
 
+    // this will allow to get search context and to perform a lookup of the same element if needed
+    public TeasyElementData getElementData() {
+        return elementData;
+    }
+
     /*
       All other methods of TeasyElement should throw an exception because it's not possible to
       interact with element that does not exist


### PR DESCRIPTION
it is still possible to waitFor().displayed() even if the actual element was NullTeasyElement

so, main usage will be:
1. wrap block around TeasyElement (doesn't matter whether it is Null or Visible element)
2. to be able to use fluent interface for cases like:
new Block(myTeasyElement).waitForBlockIsDisplayed().checkSomething();

currently it is impossible since main element of the block is 'final' and if it was instance of NullTeasyElement checkSomething() method will fail (throw NotFoundElException).

the idea is to perform additional lookup after waitForBlockIsDisplayed() and return new instance of the block with new element found by the same locator in the same context as initial NullTeasyElement